### PR TITLE
Initialize destination_path when bisync is on

### DIFF
--- a/main.py
+++ b/main.py
@@ -136,7 +136,7 @@ class Plugin:
             sync_command = "copy"
             logger.debug("using copy")
 
-            destination_path = next((x[1] for x in _get_config() if x[0] == "destination_directory"), "decky-cloud-save")
+        destination_path = next((x[1] for x in _get_config() if x[0] == "destination_directory"), "decky-cloud-save")
 
         logger.debug("Running command: %s %s --filter-from %s / backend:%s --copy-links", rclone_bin, sync_command, cfg_syncpath_filter_file, destination_path)
         self.current_sync = await asyncio.subprocess.create_subprocess_exec(rclone_bin, *[sync_command, "--filter-from", cfg_syncpath_filter_file, "/", f"backend:{destination_path}", "--copy-links"])


### PR DESCRIPTION
I was looking to try to use the bisync feature. After some debugging, I realized that `sync_now` was silently failing because it was using `destination_path` for the sync, but `destination_path` doesn't get initialized if `bisync` is on. This changes that.